### PR TITLE
add console window hiding in windows part

### DIFF
--- a/os_windows.go
+++ b/os_windows.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os/exec"
 	"strings"
+	"syscall"
 )
 
 const (
@@ -15,6 +16,9 @@ func getEdition() string {
 
 	var out bytes.Buffer
 	cmd.Stdout = &out
+	// the next 2 lines makes a console window hidden, that is expected behavior in most cases.
+	cmd.SysProcAttr = new(syscall.SysProcAttr)
+	cmd.SysProcAttr.HideWindow = true
 
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
this is not visible in console applications, but if ve create gui apps and use this package in it, we have a popupping console window that is unneeded in most cases, because we are executing console apps without HideWindow flag, this pr fixes it.