### PR TITLE
Remove unused import in dist_darwin.go

### DIFF
--- a/dist_darwin.go
+++ b/dist_darwin.go
@@ -1,7 +1,6 @@
 package osutil
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 )


### PR DESCRIPTION
https://github.com/wille/osutil/commit/20bc83f6799d321856bd600c1627071b15ef543f removed the last use of the `fmt` import in dist_darwin.go, so this PR removes the import altogether.